### PR TITLE
Improve dependencies definition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,27 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of HEPData.
+# Copyright (C) 2020 CERN.
+#
+# HEPData is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# HEPData is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with HEPData; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
 language: python
 
 python:
@@ -5,8 +29,9 @@ python:
   - "3.6"
 
 cache:
-  - apt
   - pip
+
+sudo: false
 
 addons:
   apt:
@@ -14,19 +39,16 @@ addons:
     - python-dev
 
 before_install:
-  - "travis_retry pip install --upgrade pip"
+  - "travis_retry pip install --upgrade pip setuptools wheel"
 
 install:
-  - "travis_retry pip install --upgrade -r requirements.txt"
+  - "travis_retry pip install -e .[tests]"
 
 script:
-  - python setup.py install
-  - pytest testsuite
+  - "pytest testsuite"
 
 after_success:
-  - coveralls
-
-sudo: false
+  - "coveralls"
 
 deploy:
   skip_existing: true

--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ Via GitHub (for developers):
 
    git clone https://github.com/HEPData/hepdata-validator
    cd hepdata-validator
-   pip install --upgrade -e . -r requirements.txt
+   pip install --upgrade -e .[tests]
    pytest testsuite
 
 

--- a/hepdata_validator/version.py
+++ b/hepdata_validator/version.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of HEPData.
-# Copyright (C) 2016 CERN.
+# Copyright (C) 2020 CERN.
 #
 # HEPData is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -27,4 +27,4 @@
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-pytest>=2.7.0
-coverage
-coveralls
-pyyaml
-jsonschema
-pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ import os
 from setuptools import setup
 from setuptools.command.test import test as TestCommand
 
-__author__ = 'eamonnmaguire'
 
 test_requirements = [
     'pytest>=2.7.0',
@@ -16,9 +15,11 @@ test_requirements = [
     'coverage>=3.7.1',
 ]
 
-extras_require = {'docs': ['Sphinx>=1.4.2'],
-                  'tests': test_requirements,
-                  'all': []}
+extras_require = {
+    'all': [],
+    'docs': ['Sphinx>=1.4.2'],
+    'tests': test_requirements,
+}
 
 
 class PyTest(TestCommand):
@@ -57,7 +58,7 @@ class PyTest(TestCommand):
 
 g = {}
 with open(os.path.join('hepdata_validator', 'version.py'), 'rt') as fp:
-    exec (fp.read(), g)
+    exec(fp.read(), g)
     version = g['__version__']
 
 # Get the long description from the README file


### PR DESCRIPTION
Before starting with [the _pyhf_ schema integration](https://github.com/HEPData/hepdata/issues/164), I think it is better if dependencies are defined in a single place (`setup.py`) instead of being define both in `requirements.txt` and `setup.py`.

The reason to move them to `setup.py` is because this tool lays into the _"package"_ category, not in the _"application"_  one.

In addition, I have:
- Bumped up version to `0.2.2`.
- Added license header to `.travis.yml`.
- Removed duplication of installation within `travis.yml`.
- Formatted `setup.py`.
