### PR TITLE
Simplify 'get_schema_type' logic

### DIFF
--- a/hepdata_validator/data_file_validator.py
+++ b/hepdata_validator/data_file_validator.py
@@ -137,7 +137,7 @@ class DataFileValidator(Validator):
                 message=ve.message + ' in ' + str(ve.instance),
             ))
 
-        except Exception as ex:
+        except UnsupportedDataSchemaException as ex:
             self.add_validation_message(ValidationMessage(
                 file=file_path,
                 message=ex.message,

--- a/hepdata_validator/schema_downloader.py
+++ b/hepdata_validator/schema_downloader.py
@@ -162,10 +162,7 @@ class HTTPSchemaDownloader(SchemaDownloaderInterface):
         :return: str.
         """
 
-        name, ext = schema_name.split(".")
-        schema_type = "_".join([self.org, self.project, self.version, name])
-
-        return schema_type
+        return urljoin(self.schemas_url, schema_name)
 
     def save_locally(self, schema_name, schema_spec, overwrite=False):
         """

--- a/testsuite/test_data_validator.py
+++ b/testsuite/test_data_validator.py
@@ -197,9 +197,24 @@ def test_validate_valid_custom_data_type(validator_v1, data_path):
     assert is_valid is True
 
 
-def test_load_invalid_custom_schema_v1(validator_v1):
+def test_validate_undefined_data_type(validator_v1, data_path):
     """
-    Tests the DataFileValidator V1 against an unsupported schema
+    Tests the DataFileValidator V1 validation of an unsupported schema
+    """
+
+    file_path = os.path.join(data_path, 'valid_file_custom.yaml')
+    file_type = 'undefined'
+
+    is_valid = validator_v1.validate(file_path=file_path, file_type=file_type)
+    errors = validator_v1.get_messages(file_name=file_path)
+
+    assert is_valid is False
+    assert len(errors) == 1
+
+
+def test_load_undefined_custom_schema_v1(validator_v1):
+    """
+    Tests the DataFileValidator V1 loading of an unsupported schema
     """
 
     validator_v1.custom_data_schemas = {}

--- a/testsuite/test_schema_downloader.py
+++ b/testsuite/test_schema_downloader.py
@@ -108,7 +108,7 @@ def test_http_downloader_get_schema_type(http_downloader):
     file_name = "custom.json"
 
     schema_type = http_downloader.get_schema_type(file_name)
-    assert schema_type == "testing.com_test-project_1.0.0_custom"
+    assert schema_type == "https://testing.com/test-project/schemas/1.0.0/custom.json"
 
 
 def test_http_downloader_save_schema(http_downloader):


### PR DESCRIPTION
This PR simplifies the inner logic of the [HTTPSchemaDownloader.get_schema_type](https://github.com/HEPData/hepdata-validator/blob/master/hepdata_validator/schema_downloader.py#L157) function.

The reason for this change, is that having a `HTTPSchemaDownloader` instantiated object [at the moment a custom defined schema is passed to the validator](https://github.com/HEPData/hepdata/blob/master/hepdata/modules/records/utils/submission.py#L553) is very inconvenient.

This PR has been indirectly referenced in the HEPData web-app PR that bumps up the validator version (https://github.com/HEPData/hepdata/pull/208).