### PR TITLE
Wrap RefResolutionError exception

### DIFF
--- a/hepdata_validator/schema_resolver.py
+++ b/hepdata_validator/schema_resolver.py
@@ -27,12 +27,19 @@ from abc import ABCMeta
 from abc import abstractmethod
 from copy import deepcopy
 from jsonschema import RefResolver
+from jsonschema import RefResolutionError
 
 # This is compatible both with Python2 and Python3
 try:
     from urllib.parse import urljoin
 except ImportError:                     # pragma: no cover
     from urlparse import urljoin        # pragma: no cover
+
+# This is compatible both with Python2 and Python3
+try:
+    FileNotFoundError
+except NameError:                       # pragma: no cover
+    FileNotFoundError = IOError         # pragma: no cover
 
 
 class SchemaResolverInterface(object):
@@ -147,7 +154,10 @@ class JsonSchemaResolver(SchemaResolverInterface):
         :return: dict.
         """
 
-        top_ref, top_obj = self.ref_fetcher.resolve(schema_uri)
-        resolved_schema = self._walk_dict(top_obj, top_ref)
+        try:
+            top_ref, top_obj = self.ref_fetcher.resolve(schema_uri)
+            resolved_schema = self._walk_dict(top_obj, top_ref)
+        except RefResolutionError:
+            raise FileNotFoundError("Unable to find the desired schema")
 
         return resolved_schema

--- a/hepdata_validator/version.py
+++ b/hepdata_validator/version.py
@@ -27,4 +27,4 @@
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"

--- a/testsuite/test_schema_resolver.py
+++ b/testsuite/test_schema_resolver.py
@@ -2,7 +2,12 @@ import json
 import os
 import pytest
 from hepdata_validator.schema_resolver import JsonSchemaResolver
-from jsonschema.exceptions import RefResolutionError
+
+# This is compatible both with Python2 and Python3
+try:
+    FileNotFoundError
+except NameError:                       # pragma: no cover
+    FileNotFoundError = IOError         # pragma: no cover
 
 
 ####################################################
@@ -71,5 +76,5 @@ def test_json_resolver_non_existing_schema(json_resolver):
 
     file_name = "random_name.json"
 
-    with pytest.raises(RefResolutionError):
+    with pytest.raises(FileNotFoundError):
         json_resolver.resolve(file_name)


### PR DESCRIPTION
This PR is derived from the _"Remote schema validations"_ PR in the main repository (https://github.com/HEPData/hepdata/pull/241).

In a nutshell, it encapsulates `jsonschema` specific exceptions (in this case `RefResolutionError`) so that they do not get propagated up the stack forcing to have `jsonschema` as a requirements in the upper layer HEPData application.

I think `FileNotFoundError` (Python3+) is the right exception to propagate. For Python2 envs, `IOError` is used.

#### Additional clarifications:
- I have bumped up version to `0.2.3`.

#### Unrelated notice:
For some reason, I have permissions to create branches on the main repo ([hepdata/hepdata](https://github.com/HEPData/hepdata)), but not on this repository. Could we fix this?