### PR TITLE
Reinstate support for Python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,14 @@ jobs:
 
   test:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9' ]
+        runner: ['ubuntu-latest']
+        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
+        include:
+          - runner: 'ubuntu-20.04'
+            python-version: '3.6'
 
     steps:
     - uses: actions/checkout@v3

--- a/hepdata_validator/version.py
+++ b/hepdata_validator/version.py
@@ -27,4 +27,4 @@
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.3.4"
+__version__ = "0.3.5"

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
     test_suite='hepdata_validator.testsuite',
     tests_require=test_requirements,
     cmdclass={'test': PyTest},
-    python_requires='>=3.7',
+    python_requires='>=3.6',
     entry_points={
         'console_scripts': ['hepdata-validate=hepdata_validator.cli:validate'],
     }


### PR DESCRIPTION
* Run Python 3.6 tests using older 'ubuntu-20.04' image.
* Also add tests for Python 3.10 and 3.11.
* Bump version to 0.3.5 in preparation for new release.