### PR TITLE
docs: Add conda-forge distribution badge to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,10 @@
    :target: https://pypi.org/project/hepdata-validator/
    :alt: PyPI Version
 
+.. image:: https://img.shields.io/conda/vn/conda-forge/hepdata-validator.svg
+   :target: https://prefix.dev/channels/conda-forge/packages/hepdata-validator
+   :alt: conda-forge Version
+
 .. image:: https://img.shields.io/github/issues/hepdata/hepdata-validator.svg?maxAge=2592000
    :target: https://github.com/HEPData/hepdata-validator/issues
    :alt: GitHub Issues

--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,13 @@ with the LibYAML bindings. Run the following after installing LibYAML via Homebr
 
   $ LDFLAGS="-L$(brew --prefix)/lib" CFLAGS="-I$(brew --prefix)/include" pip install --global-option="--with-libyaml" --force pyyaml
 
+Alternatively, install from `conda-forge <https://anaconda.org/conda-forge/hepdata-validator>`_ using a ``conda`` ecosystem package manager:
+
+.. code:: bash
+
+   $ conda install --channel conda-forge hepdata-validator
+   $ hepdata-validate --help
+
 
 Developers
 ==========


### PR DESCRIPTION
* Add badge for conda-forge distribution to README.
   - c.f. https://anaconda.org/conda-forge/hepdata-validator
   - Use prefix.dev's view as it provides much better user information.
* Add conda-forge install instructions to README.

[![conda-forge version](https://img.shields.io/conda/vn/conda-forge/hepdata-validator.svg)](https://prefix.dev/channels/conda-forge/packages/hepdata-validator)

c.f. https://github.com/conda-forge/staged-recipes/pull/26279 and https://github.com/conda-forge/hepdata-validator-feedstock/