### PR TITLE
Remove `coverage<6.0` pin, upgrade actions and add Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,15 +17,15 @@ jobs:
     strategy:
       matrix:
         runner: ['ubuntu-latest']
-        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12' ]
         include:
           - runner: 'ubuntu-20.04'
             python-version: '3.6'
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install pip dependencies
@@ -61,9 +61,9 @@ jobs:
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.9
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.9'
     - name: Build PyPI package

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ test_requirements = [
     "pytest-cache>=1.0",
     'pytest-cov>=1.8.0',
     'pytest-pep8>=1.0.6',
-    'coverage>=3.7.1,<6.0',
+    'coverage>=3.7.1',
     'mock>=2.0.0',
 ]
 


### PR DESCRIPTION
* Remove the pin `coverage<6.0` to allow the CI to pass with Python 3.11 (closes #62).
* Upgrade the `checkout` and `setup-python` actions to their latest versions.
* Add Python 3.12 to the test matrix.