### PR TITLE
Sanity checks concerning under-/overflow bins

### DIFF
--- a/hepdata_validator/data_file_validator.py
+++ b/hepdata_validator/data_file_validator.py
@@ -184,33 +184,40 @@ class DataFileValidator(Validator):
                         )
                         self.add_validation_error(file_path, error)
                 if 'low' in v and 'high' in v:
-                    if math.isinf(v['low']) and math.isinf(v['high']):
+                    lo = None
+                    hi = None
+                    try:
+                        lo = float(v['low'])
+                        hi = float(v['high'])
+                    except:
+                        continue
+                    if math.isinf(lo) and math.isinf(hi):
                         error = ValidationError(
                             "independent_variable 'low' and 'high' must not both have infinite values: '%s' and '%s'" % (v['low'], v['high']),
                             path=['independent_variables', i, 'values', j],
-                            instance=data_item['independent_variables'],
+                            instance=data_item['independent_variables']
                         )
                         self.add_validation_error(file_path, error)
-                    elif math.isinf(v['low']):
-                        of_id = "(%s, %.4e)" % (str(v['low']), float(v['high']))
+                    elif math.isinf(lo):
+                        of_id = "(%s, %.4e)" % (str(v['low']), hi)
                         if of_id not in underflows:
                             underflows.append(of_id)
-                    elif math.isinf(v['high']):
-                        of_id = "(%.4e, %s)" % (float(v['low']), str(v['high']))
+                    elif math.isinf(hi):
+                        of_id = "(%.4e, %s)" % (lo, str(v['high']))
                         if of_id not in overflows:
                             overflows.append(of_id)
             if len(underflows) > 1:
                 error = ValidationError(
                     "independent_variable must not have more than one underflow bin: %s" % ", ".join(underflows),
                     path=['independent_variables', i, 'values', j],
-                    instance=data_item['independent_variables'],
+                    instance=data_item['independent_variables']
                 )
                 self.add_validation_error(file_path, error)
             if len(overflows) > 1:
                 error = ValidationError(
                     "independent_variable must not have more than one overflow bin: %s" % ", ".join(overflows),
                     path=['independent_variables', i, 'values', j],
-                    instance=data_item['independent_variables'],
+                    instance=data_item['independent_variables']
                 )
                 self.add_validation_error(file_path, error)
 

--- a/testsuite/test_data/invalid_independent_variables_file.yaml
+++ b/testsuite/test_data/invalid_independent_variables_file.yaml
@@ -16,7 +16,7 @@ independent_variables:
         high: .inf
       - low: -.inf
         high: 0.0
-      - low: .inf
+      - low: -.inf
         high: 1.0
       - low: 0.0
         high: .inf

--- a/testsuite/test_data/invalid_independent_variables_file.yaml
+++ b/testsuite/test_data/invalid_independent_variables_file.yaml
@@ -12,6 +12,16 @@ independent_variables:
       - value: '-1e-09 - -3.5e-08'
       - value: 'Mono-V overlap removal' # OK
       - value: '-3.5' # OK
+      - low: -.inf
+        high: .inf
+      - low: -.inf
+        high: 0.0
+      - low: .inf
+        high: 1.0
+      - low: 0.0
+        high: .inf
+      - low: 1.0
+        high: .inf
 dependent_variables:
   - header: {name: SIG(total), units: FB}
     qualifiers:
@@ -58,6 +68,31 @@ dependent_variables:
           - {asymerror: {plus: 0.42, minus: 0.31}, label: sys}
           - {symerror: 0.4, label: "sys,lumi"}
       - value: 13.7
+        errors:
+          - {symerror: 0.4, label: stat}
+          - {asymerror: {plus: 0.42, minus: 0.31}, label: sys}
+          - {symerror: 0.4, label: "sys,lumi"}
+      - value: 14.7
+        errors:
+          - {symerror: 0.4, label: stat}
+          - {asymerror: {plus: 0.42, minus: 0.31}, label: sys}
+          - {symerror: 0.4, label: "sys,lumi"}
+      - value: 15.7
+        errors:
+          - {symerror: 0.4, label: stat}
+          - {asymerror: {plus: 0.42, minus: 0.31}, label: sys}
+          - {symerror: 0.4, label: "sys,lumi"}
+      - value: 16.7
+        errors:
+          - {symerror: 0.4, label: stat}
+          - {asymerror: {plus: 0.42, minus: 0.31}, label: sys}
+          - {symerror: 0.4, label: "sys,lumi"}
+      - value: 17.7
+        errors:
+          - {symerror: 0.4, label: stat}
+          - {asymerror: {plus: 0.42, minus: 0.31}, label: sys}
+          - {symerror: 0.4, label: "sys,lumi"}
+      - value: 18.7
         errors:
           - {symerror: 0.4, label: stat}
           - {asymerror: {plus: 0.42, minus: 0.31}, label: sys}

--- a/testsuite/test_data_validator.py
+++ b/testsuite/test_data_validator.py
@@ -377,7 +377,7 @@ def test_file_with_invalid_independent_variables_v1(validator_v1, data_path, cap
     assert lines[5].strip() == "error - independent_variable 'value' must not be a string range (use 'low' and 'high' to represent a range): '+2.3E5 -  +5E12' in 'independent_variables[0].values[5].value' (expected: {'type': 'number or string (not a range)'})"
     assert lines[6].strip() == "error - independent_variable 'value' must not be a string range (use 'low' and 'high' to represent a range): '-1e-09 - -3.5e-08' in 'independent_variables[0].values[6].value' (expected: {'type': 'number or string (not a range)'})"
     assert lines[7].strip() == "error - independent_variable 'low' and 'high' must not both have infinite values: '-inf' and 'inf' in 'independent_variables[0].values[9]'"
-    assert lines[8].strip() == "error - independent_variable must not have more than one underflow bin: (-inf, 0.0000e+00), (inf, 1.0000e+00) in 'independent_variables[0].values[13]'"
+    assert lines[8].strip() == "error - independent_variable must not have more than one underflow bin: (-inf, 0.0000e+00), (-inf, 1.0000e+00) in 'independent_variables[0].values[13]'"
     assert lines[9].strip() == "error - independent_variable must not have more than one overflow bin: (0.0000e+00, inf), (1.0000e+00, inf) in 'independent_variables[0].values[13]'"
 
 

--- a/testsuite/test_data_validator.py
+++ b/testsuite/test_data_validator.py
@@ -368,7 +368,7 @@ def test_file_with_invalid_independent_variables_v1(validator_v1, data_path, cap
     assert is_valid is False
     out, err = capsys.readouterr()
     lines = out.splitlines()
-    assert len(lines) == 7
+    assert len(lines) == 10
     assert lines[0].strip() == "error - {'low': 6000} is not valid under any of the given schemas in 'independent_variables[0].values[0]' (expected: {'oneOf': [{'type': 'object', 'properties': {'value': {'type': ['string', 'number']}}, 'required': ['value'], 'additionalProperties': False}, {'type': 'object', 'properties': {'value': {'type': 'number'}, 'low': {'type': 'number'}, 'high': {'type': 'number'}}, 'required': ['low', 'high'], 'additionalProperties': False}]})"
     assert lines[1].strip() == "error - {'high': 7000} is not valid under any of the given schemas in 'independent_variables[0].values[1]' (expected: {'oneOf': [{'type': 'object', 'properties': {'value': {'type': ['string', 'number']}}, 'required': ['value'], 'additionalProperties': False}, {'type': 'object', 'properties': {'value': {'type': 'number'}, 'low': {'type': 'number'}, 'high': {'type': 'number'}}, 'required': ['low', 'high'], 'additionalProperties': False}]})"
     assert lines[2].strip() == "error - {'high': '7.0.0', 'low': '2.0.0'} is not valid under any of the given schemas in 'independent_variables[0].values[2]' (expected: {'oneOf': [{'type': 'object', 'properties': {'value': {'type': ['string', 'number']}}, 'required': ['value'], 'additionalProperties': False}, {'type': 'object', 'properties': {'value': {'type': 'number'}, 'low': {'type': 'number'}, 'high': {'type': 'number'}}, 'required': ['low', 'high'], 'additionalProperties': False}]})"
@@ -376,6 +376,9 @@ def test_file_with_invalid_independent_variables_v1(validator_v1, data_path, cap
     assert lines[4].strip() == "error - independent_variable 'value' must not be a string range (use 'low' and 'high' to represent a range): '-5.3--2' in 'independent_variables[0].values[4].value' (expected: {'type': 'number or string (not a range)'})"
     assert lines[5].strip() == "error - independent_variable 'value' must not be a string range (use 'low' and 'high' to represent a range): '+2.3E5 -  +5E12' in 'independent_variables[0].values[5].value' (expected: {'type': 'number or string (not a range)'})"
     assert lines[6].strip() == "error - independent_variable 'value' must not be a string range (use 'low' and 'high' to represent a range): '-1e-09 - -3.5e-08' in 'independent_variables[0].values[6].value' (expected: {'type': 'number or string (not a range)'})"
+    assert lines[7].strip() == "error - independent_variable 'low' and 'high' must not both have infinite values: '-inf' and 'inf' in 'independent_variables[0].values[9]'"
+    assert lines[8].strip() == "error - independent_variable must not have more than one underflow bin: (-inf, 0.0000e+00), (inf, 1.0000e+00) in 'independent_variables[0].values[13]'"
+    assert lines[9].strip() == "error - independent_variable must not have more than one overflow bin: (0.0000e+00, inf), (1.0000e+00, inf) in 'independent_variables[0].values[13]'"
 
 
 def test_file_with_missing_dependent_values_v1(validator_v1, data_path, capsys):


### PR DESCRIPTION
Closes #56

This change set counts the under-/overflow bins along each independent axis, ensuring that
* A bin must not have `low` and `high` limits that are both infinite
* Only one set of underflow- and one set of overflow-like `low`/`high` pairs are allowed per independent axis
* Extends the existing unit-test for independent axes