### PR TITLE
ci: drop Python 3.6 and add Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,8 @@ jobs:
     strategy:
       matrix:
         runner: ['ubuntu-latest']
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12', '3.13' ]
         include:
-          - runner: 'ubuntu-20.04'
-            python-version: '3.6'
           - runner: 'ubuntu-22.04'
             python-version: '3.7'
 


### PR DESCRIPTION
The Ubuntu 20.04 runner image from GitHub Actions (needed to run the Python 3.6 tests) is deprecated and will be fully unsupported by 2025-04-15 (actions/runner-images#11101).  I've therefore removed the Python 3.6 tests from the CI (and added Python 3.13).  I've kept `python_requires='>=3.6'` in the `setup.py` file, because the [`hepdata_lib`](https://github.com/HEPData/hepdata_lib) testing requires a version of the `hepdata-validator` compatible with Python 3.6.  The `hepdata_lib` testing uses Micromamba for setting up Python 3.6 rather than relying on the runner images provided in GitHub Actions.  I'll create a new issue to either drop Python 3.6 support in the `hepdata-validator` (e.g. after `hepdata_lib` drops support) or re-add testing for Python 3.6 (e.g. using Micromamba).